### PR TITLE
Add disable_snapshot_annotations = false to work with containerd v1.4.2 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A basic configuration would look like:
 # tell containerd to use this particular snapshotter
 [plugins."io.containerd.grpc.v1.cri".containerd]
   snapshotter = "cvmfs-snapshotter"
+  disable_snapshot_annotations = false
 
 # tell containerd how to communicate with this snapshotter
 [proxy_plugins]

--- a/script/config/etc/containerd/config.toml
+++ b/script/config/etc/containerd/config.toml
@@ -8,6 +8,7 @@ version = 2
 [plugins."io.containerd.grpc.v1.cri".containerd]
   default_runtime_name = "runc"
   snapshotter = "cvmfs-snapshotter"
+  disable_snapshot_annotations = false
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
   runtime_type = "io.containerd.runc.v2"
 


### PR DESCRIPTION
This follows the discussion in https://github.com/containerd/stargz-snapshotter/issues/251 and updates both the documentation as well as the `config.toml` for containerd.