### PR TITLE
unmount all when exiting form the container

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,12 +120,13 @@ func main() {
 			log.G(ctx).WithError(err).Fatalf("error on serving via socket %q", *address)
 		}
 	}()
-	waitForSIGINT()
+	waitForSIGINT(fs.(*cvmfs.Filesystem))
 	log.G(ctx).Info("Got SIGINT")
 }
 
-func waitForSIGINT() {
+func waitForSIGINT(fs *cvmfs.Filesystem) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c
+	fs.UnmountAll()
 }


### PR DESCRIPTION
It was reported that, sometimes, some moutpoint are left hanging. It is a problem since it does not allow to remount the cvmfs filesystem.

With this PR, on exit, we unmount everything.